### PR TITLE
Update Fedora requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sudo dnf install xsel xclip
 sudo dnf install libpng-devel
 
 # GoHook
-sudo dnf install libxkbcommon-devel libxkbcommon-x11-devel xorg-x11-xkb-utils-devel
+sudo dnf install libxkbcommon-devel libxkbcommon-x11-devel xkbcomp-devel
 
 ```
 


### PR DESCRIPTION
Updated readme for Fedora requirements as the package xorg-x11-xkb-utils-devel seems to have moved to xkbcomp-devel in later Fedora versions
